### PR TITLE
Added RestHighLevelClientProvider

### DIFF
--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSink.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSink.java
@@ -59,19 +59,22 @@ public class OpensearchSink<IN> implements Sink<IN> {
     private final BulkProcessorConfig buildBulkProcessorConfig;
     private final NetworkClientConfig networkClientConfig;
     private final DeliveryGuarantee deliveryGuarantee;
+    private final RestHighLevelClientProvider restClientProvider;
 
     OpensearchSink(
             List<HttpHost> hosts,
             OpensearchEmitter<? super IN> emitter,
             DeliveryGuarantee deliveryGuarantee,
             BulkProcessorConfig buildBulkProcessorConfig,
-            NetworkClientConfig networkClientConfig) {
+            NetworkClientConfig networkClientConfig,
+            RestHighLevelClientProvider restClientProvider) {
         this.hosts = checkNotNull(hosts);
         checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
         this.emitter = checkNotNull(emitter);
         this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
         this.buildBulkProcessorConfig = checkNotNull(buildBulkProcessorConfig);
         this.networkClientConfig = checkNotNull(networkClientConfig);
+        this.restClientProvider = restClientProvider;
     }
 
     @Override
@@ -83,7 +86,8 @@ public class OpensearchSink<IN> implements Sink<IN> {
                 buildBulkProcessorConfig,
                 networkClientConfig,
                 context.metricGroup(),
-                context.getMailboxExecutor());
+                context.getMailboxExecutor(),
+                restClientProvider);
     }
 
     @VisibleForTesting

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
@@ -72,6 +72,7 @@ public class OpensearchSinkBuilder<IN> {
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
     private Boolean allowInsecure;
+    private RestHighLevelClientProvider restClientProvider = null;
 
     public OpensearchSinkBuilder() {}
 
@@ -286,6 +287,18 @@ public class OpensearchSinkBuilder<IN> {
     }
 
     /**
+     * Allows to set custom RestClient provider. If not set, then the default RestHighLevelClient will be
+     * used.
+     *
+     * @param restClientProvider the custom provider
+     * @return this builder
+     */
+    public OpensearchSinkBuilder<IN> setRestClientProvider(RestHighLevelClientProvider restClientProvider) {
+        this.restClientProvider = restClientProvider;
+        return self();
+    }
+
+    /**
      * Constructs the {@link OpensearchSink} with the properties configured this builder.
      *
      * @return {@link OpensearchSink}
@@ -298,7 +311,7 @@ public class OpensearchSinkBuilder<IN> {
         BulkProcessorConfig bulkProcessorConfig = buildBulkProcessorConfig();
 
         return new OpensearchSink<>(
-                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig);
+                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig, restClientProvider);
     }
 
     private NetworkClientConfig buildNetworkClientConfig() {

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
@@ -287,13 +287,14 @@ public class OpensearchSinkBuilder<IN> {
     }
 
     /**
-     * Allows to set custom RestClient provider. If not set, then the default RestHighLevelClient will be
-     * used.
+     * Allows to set custom RestClient provider. If not set, then the default RestHighLevelClient
+     * will be used.
      *
      * @param restClientProvider the custom provider
      * @return this builder
      */
-    public OpensearchSinkBuilder<IN> setRestClientProvider(RestHighLevelClientProvider restClientProvider) {
+    public OpensearchSinkBuilder<IN> setRestClientProvider(
+            RestHighLevelClientProvider restClientProvider) {
         this.restClientProvider = restClientProvider;
         return self();
     }
@@ -311,7 +312,12 @@ public class OpensearchSinkBuilder<IN> {
         BulkProcessorConfig bulkProcessorConfig = buildBulkProcessorConfig();
 
         return new OpensearchSink<>(
-                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig, restClientProvider);
+                hosts,
+                emitter,
+                deliveryGuarantee,
+                bulkProcessorConfig,
+                networkClientConfig,
+                restClientProvider);
     }
 
     private NetworkClientConfig buildNetworkClientConfig() {

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
@@ -103,11 +103,12 @@ class OpensearchWriter<IN> implements SinkWriter<IN> {
             BulkProcessorConfig bulkProcessorConfig,
             NetworkClientConfig networkClientConfig,
             SinkWriterMetricGroup metricGroup,
+            RestHighLevelClientProvider restClientProvider,
             MailboxExecutor mailboxExecutor) {
         this.emitter = checkNotNull(emitter);
         this.flushOnCheckpoint = flushOnCheckpoint;
         this.mailboxExecutor = checkNotNull(mailboxExecutor);
-        this.client =
+        this.client = restClientProvider != null ? restClientProvider.getProvider(hosts, networkClientConfig) : 
                 new RestHighLevelClient(
                         configureRestClientBuilder(
                                 RestClient.builder(hosts.toArray(new HttpHost[0])),

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
@@ -103,16 +103,18 @@ class OpensearchWriter<IN> implements SinkWriter<IN> {
             BulkProcessorConfig bulkProcessorConfig,
             NetworkClientConfig networkClientConfig,
             SinkWriterMetricGroup metricGroup,
-            RestHighLevelClientProvider restClientProvider,
-            MailboxExecutor mailboxExecutor) {
+            MailboxExecutor mailboxExecutor,
+            RestHighLevelClientProvider restClientProvider) {
         this.emitter = checkNotNull(emitter);
         this.flushOnCheckpoint = flushOnCheckpoint;
         this.mailboxExecutor = checkNotNull(mailboxExecutor);
-        this.client = restClientProvider != null ? restClientProvider.getProvider(hosts, networkClientConfig) : 
-                new RestHighLevelClient(
-                        configureRestClientBuilder(
-                                RestClient.builder(hosts.toArray(new HttpHost[0])),
-                                networkClientConfig));
+        this.client =
+                restClientProvider != null
+                        ? restClientProvider.getProvider(hosts, networkClientConfig)
+                        : new RestHighLevelClient(
+                                configureRestClientBuilder(
+                                        RestClient.builder(hosts.toArray(new HttpHost[0])),
+                                        networkClientConfig));
         this.bulkProcessor = createBulkProcessor(bulkProcessorConfig);
         this.requestIndexer = new DefaultRequestIndexer(metricGroup.getNumRecordsSendCounter());
         checkNotNull(metricGroup);
@@ -308,9 +310,11 @@ class OpensearchWriter<IN> implements SinkWriter<IN> {
 
     private void enqueueActionInMailbox(
             ThrowingRunnable<? extends Exception> action, String actionName) {
-        // If the writer is cancelled before the last bulk response (i.e. no flush on checkpoint
+        // If the writer is cancelled before the last bulk response (i.e. no flush on
+        // checkpoint
         // configured or shutdown without a final
-        // checkpoint) the mailbox might already be shutdown, so we should not enqueue any
+        // checkpoint) the mailbox might already be shutdown, so we should not enqueue
+        // any
         // actions.
         if (isClosed()) {
             return;

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/RestHighLevelClientProvider.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/RestHighLevelClientProvider.java
@@ -20,11 +20,15 @@ package org.apache.flink.connector.opensearch.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.Serializable;
+import org.apache.http.HttpHost;
+import org.opensearch.client.RestHighLevelClient;
 
-/** Custom RestHighLevelClient provider */
-@PublicEvolving
+import java.io.Serializable;
+import java.util.List;
+
+/** Custom RestHighLevelClient provider. */
 @FunctionalInterface
+@PublicEvolving
 public interface RestHighLevelClientProvider extends Serializable {
     RestHighLevelClient getProvider(List<HttpHost> hosts, NetworkClientConfig networkClientConfig);
 }

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/RestHighLevelClientProvider.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/RestHighLevelClientProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.opensearch.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/** Custom RestHighLevelClient provider */
+@PublicEvolving
+@FunctionalInterface
+public interface RestHighLevelClientProvider extends Serializable {
+    RestHighLevelClient getProvider(List<HttpHost> hosts, NetworkClientConfig networkClientConfig);
+}

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
@@ -66,8 +66,8 @@ class OpensearchWriterITCase {
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchWriterITCase.class);
 
     @Container
-    private static final OpensearchContainer OS_CONTAINER =
-            OpensearchUtil.createOpensearchContainer(DockerImageVersions.OPENSEARCH_1, LOG);
+    private static final OpensearchContainer OS_CONTAINER = OpensearchUtil
+            .createOpensearchContainer(DockerImageVersions.OPENSEARCH_1, LOG);
 
     private RestHighLevelClient client;
     private OpensearchTestClient context;
@@ -91,11 +91,10 @@ class OpensearchWriterITCase {
     void testWriteOnBulkFlush() throws Exception {
         final String index = "test-bulk-flush-without-checkpoint";
         final int flushAfterNActions = 5;
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
+                FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, false, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -124,11 +123,10 @@ class OpensearchWriterITCase {
         final String index = "test-bulk-flush-with-interval";
 
         // Configure bulk processor to flush every 1s;
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(-1, -1, 1000, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(-1, -1, 1000, FlushBackoffType.NONE, 0,
+                0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, false, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -142,12 +140,11 @@ class OpensearchWriterITCase {
     @Test
     void testWriteOnCheckpoint() throws Exception {
         final String index = "test-bulk-flush-with-checkpoint";
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(-1, -1, -1, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(-1, -1, -1, FlushBackoffType.NONE, 0,
+                0);
 
         // Enable flush on checkpoint
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, true, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, true, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -164,17 +161,16 @@ class OpensearchWriterITCase {
     @Test
     void testIncrementByteOutMetric() throws Exception {
         final String index = "test-inc-byte-out";
-        final OperatorIOMetricGroup operatorIOMetricGroup =
-                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
-        final InternalSinkWriterMetricGroup metricGroup =
-                InternalSinkWriterMetricGroup.mock(
-                        metricListener.getMetricGroup(), operatorIOMetricGroup);
+        final OperatorIOMetricGroup operatorIOMetricGroup = UnregisteredMetricGroups
+                .createUnregisteredOperatorMetricGroup().getIOMetricGroup();
+        final InternalSinkWriterMetricGroup metricGroup = InternalSinkWriterMetricGroup.mock(
+                metricListener.getMetricGroup(), operatorIOMetricGroup);
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
+                FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, false, bulkProcessorConfig, metricGroup)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig,
+                metricGroup)) {
             final Counter numBytesOut = operatorIOMetricGroup.getNumBytesOutCounter();
             assertThat(numBytesOut.getCount()).isEqualTo(0);
             writer.write(Tuple2.of(1, buildMessage(1)), null);
@@ -197,13 +193,11 @@ class OpensearchWriterITCase {
     void testIncrementRecordsSendMetric() throws Exception {
         final String index = "test-inc-records-send";
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
+                FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, false, bulkProcessorConfig)) {
-            final Optional<Counter> recordsSend =
-                    metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Counter> recordsSend = metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             // Update existing index
             writer.write(Tuple2.of(1, "u" + buildMessage(2)), null);
@@ -221,13 +215,11 @@ class OpensearchWriterITCase {
     void testCurrentSendTime() throws Exception {
         final String index = "test-current-send-time";
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig =
-                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
+                FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
-                createWriter(index, false, bulkProcessorConfig)) {
-            final Optional<Gauge<Long>> currentSendTime =
-                    metricListener.getGauge("currentSendTime");
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Gauge<Long>> currentSendTime = metricListener.getGauge("currentSendTime");
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
 
@@ -266,7 +258,8 @@ class OpensearchWriterITCase {
                         null,
                         true),
                 metricGroup,
-                new TestMailbox());
+                new TestMailbox(),
+                null);
     }
 
     private static class UpdatingEmitter implements OpensearchEmitter<Tuple2<Integer, String>> {
@@ -292,20 +285,17 @@ class OpensearchWriterITCase {
             final char action = element.f1.charAt(0);
             final String id = element.f0.toString();
             switch (action) {
-                case 'd':
-                    {
-                        indexer.add(new DeleteRequest(index).id(id));
-                        break;
-                    }
-                case 'u':
-                    {
-                        indexer.add(new UpdateRequest().index(index).id(id).doc(document));
-                        break;
-                    }
-                default:
-                    {
-                        indexer.add(new IndexRequest(index).id(id).source(document));
-                    }
+                case 'd': {
+                    indexer.add(new DeleteRequest(index).id(id));
+                    break;
+                }
+                case 'u': {
+                    indexer.add(new UpdateRequest().index(index).id(id).doc(document));
+                    break;
+                }
+                default: {
+                    indexer.add(new IndexRequest(index).id(id).source(document));
+                }
             }
         }
     }

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
@@ -66,8 +66,8 @@ class OpensearchWriterITCase {
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchWriterITCase.class);
 
     @Container
-    private static final OpensearchContainer OS_CONTAINER = OpensearchUtil
-            .createOpensearchContainer(DockerImageVersions.OPENSEARCH_1, LOG);
+    private static final OpensearchContainer OS_CONTAINER =
+            OpensearchUtil.createOpensearchContainer(DockerImageVersions.OPENSEARCH_1, LOG);
 
     private RestHighLevelClient client;
     private OpensearchTestClient context;
@@ -91,10 +91,11 @@ class OpensearchWriterITCase {
     void testWriteOnBulkFlush() throws Exception {
         final String index = "test-bulk-flush-without-checkpoint";
         final int flushAfterNActions = 5;
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
-                FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -123,10 +124,11 @@ class OpensearchWriterITCase {
         final String index = "test-bulk-flush-with-interval";
 
         // Configure bulk processor to flush every 1s;
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(-1, -1, 1000, FlushBackoffType.NONE, 0,
-                0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(-1, -1, 1000, FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -140,11 +142,12 @@ class OpensearchWriterITCase {
     @Test
     void testWriteOnCheckpoint() throws Exception {
         final String index = "test-bulk-flush-with-checkpoint";
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(-1, -1, -1, FlushBackoffType.NONE, 0,
-                0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(-1, -1, -1, FlushBackoffType.NONE, 0, 0);
 
         // Enable flush on checkpoint
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, true, bulkProcessorConfig)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, true, bulkProcessorConfig)) {
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
             writer.write(Tuple2.of(3, buildMessage(3)), null);
@@ -161,16 +164,17 @@ class OpensearchWriterITCase {
     @Test
     void testIncrementByteOutMetric() throws Exception {
         final String index = "test-inc-byte-out";
-        final OperatorIOMetricGroup operatorIOMetricGroup = UnregisteredMetricGroups
-                .createUnregisteredOperatorMetricGroup().getIOMetricGroup();
-        final InternalSinkWriterMetricGroup metricGroup = InternalSinkWriterMetricGroup.mock(
-                metricListener.getMetricGroup(), operatorIOMetricGroup);
+        final OperatorIOMetricGroup operatorIOMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
+        final InternalSinkWriterMetricGroup metricGroup =
+                InternalSinkWriterMetricGroup.mock(
+                        metricListener.getMetricGroup(), operatorIOMetricGroup);
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
-                FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig,
-                metricGroup)) {
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, false, bulkProcessorConfig, metricGroup)) {
             final Counter numBytesOut = operatorIOMetricGroup.getNumBytesOutCounter();
             assertThat(numBytesOut.getCount()).isEqualTo(0);
             writer.write(Tuple2.of(1, buildMessage(1)), null);
@@ -193,11 +197,13 @@ class OpensearchWriterITCase {
     void testIncrementRecordsSendMetric() throws Exception {
         final String index = "test-inc-records-send";
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
-                FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
-            final Optional<Counter> recordsSend = metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Counter> recordsSend =
+                    metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             // Update existing index
             writer.write(Tuple2.of(1, "u" + buildMessage(2)), null);
@@ -215,11 +221,13 @@ class OpensearchWriterITCase {
     void testCurrentSendTime() throws Exception {
         final String index = "test-current-send-time";
         final int flushAfterNActions = 2;
-        final BulkProcessorConfig bulkProcessorConfig = new BulkProcessorConfig(flushAfterNActions, -1, -1,
-                FlushBackoffType.NONE, 0, 0);
+        final BulkProcessorConfig bulkProcessorConfig =
+                new BulkProcessorConfig(flushAfterNActions, -1, -1, FlushBackoffType.NONE, 0, 0);
 
-        try (final OpensearchWriter<Tuple2<Integer, String>> writer = createWriter(index, false, bulkProcessorConfig)) {
-            final Optional<Gauge<Long>> currentSendTime = metricListener.getGauge("currentSendTime");
+        try (final OpensearchWriter<Tuple2<Integer, String>> writer =
+                createWriter(index, false, bulkProcessorConfig)) {
+            final Optional<Gauge<Long>> currentSendTime =
+                    metricListener.getGauge("currentSendTime");
             writer.write(Tuple2.of(1, buildMessage(1)), null);
             writer.write(Tuple2.of(2, buildMessage(2)), null);
 
@@ -285,17 +293,20 @@ class OpensearchWriterITCase {
             final char action = element.f1.charAt(0);
             final String id = element.f0.toString();
             switch (action) {
-                case 'd': {
-                    indexer.add(new DeleteRequest(index).id(id));
-                    break;
-                }
-                case 'u': {
-                    indexer.add(new UpdateRequest().index(index).id(id).doc(document));
-                    break;
-                }
-                default: {
-                    indexer.add(new IndexRequest(index).id(id).source(document));
-                }
+                case 'd':
+                    {
+                        indexer.add(new DeleteRequest(index).id(id));
+                        break;
+                    }
+                case 'u':
+                    {
+                        indexer.add(new UpdateRequest().index(index).id(id).doc(document));
+                        break;
+                    }
+                default:
+                    {
+                        indexer.add(new IndexRequest(index).id(id).source(document));
+                    }
             }
         }
     }


### PR DESCRIPTION
should point at origin and not fork when done

Inspired by:
https://github.com/apache/flink-connector-opensearch/pull/11/files